### PR TITLE
Throw on not supported upsert & getOrCreate methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,12 +102,12 @@ export class PineTest extends PinejsClientCore<PineTest> {
 		>;
 	}
 
-	public upsert(
-		...args: Parameters<PinejsClientCore<PineTest>['upsert']>
-	): PromiseResult<ResolvableReturnType<PinejsClientCore<PineTest>['upsert']>> {
-		return super.upsert(...args) as PromiseResult<
-			ResolvableReturnType<PinejsClientCore<PineTest>['upsert']>
-		>;
+	public upsert(): never {
+		throw new Error('upsert is not supported by pinejs-client-supertest');
+	}
+
+	public getOrCreate(): never {
+		throw new Error('getOrCreate is not supported by pinejs-client-supertest');
 	}
 
 	public request(


### PR DESCRIPTION
These were already not running as expected and
even after trying to re-implement them I didn't
manage to reach a non-hacky result in a sane
amount of time. On top of that, given that this
library is primarily targeting testing endpoints,
those two methods should be avoided since they
provide an abstraction on top of two other calls.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/ls1DJ3iexOESbtTzkftN8pQ9KoU
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>