### PR TITLE
Allow passing a url string as the `app` instead of an Express app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ type ResolvableReturnType<T extends (...args: any[]) => any> = T extends (
 	: any;
 
 interface BackendParams {
-	app: express.Express;
+	app: express.Express | string;
 }
 
 /** A pine testing client fused with the api of supertest */

--- a/src/supertest.ts
+++ b/src/supertest.ts
@@ -2,7 +2,7 @@ import type * as express from 'express';
 import * as supertest from 'supertest';
 import { UserParam } from './common';
 
-export default function (app: express.Express, user?: UserParam) {
+export default function (app: express.Express | string, user?: UserParam) {
 	// Can be an object with `token`, a JWT string or an API key string
 	let token = user;
 	if (typeof user === 'object' && user.token) {


### PR DESCRIPTION
Change-type: minor