### PR TITLE
Correctly type that all properties are selected with a missing $select

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,13 +25,15 @@ type SelectPropsOf<T extends Resource['Read'], U extends ODataOptions<T>> =
 		? U['$select'][number]
 		: U['$select'] extends StringKeyOf<T>
 			? U['$select']
-			: never;
+			: // If no $select is provided, all properties are selected
+				StringKeyOf<T>;
 type ExpandPropsOf<T extends Resource['Read'], U extends ODataOptions<T>> =
 	U['$expand'] extends ReadonlyArray<StringKeyOf<T>>
 		? U['$expand'][number]
 		: U['$expand'] extends { [key in StringKeyOf<T>]?: any }
 			? StringKeyOf<U['$expand']>
-			: never;
+			: // If no $expand is provided, no properties are expanded
+				never;
 
 type supportedMethod = 'get' | 'put' | 'patch' | 'post' | 'delete';
 


### PR DESCRIPTION
Change-type: patch